### PR TITLE
Prepare release 1.6.0

### DIFF
--- a/pyjet/__init__.py
+++ b/pyjet/__init__.py
@@ -2,11 +2,16 @@ from ._libpyjet import (ClusterSequence, ClusterSequenceArea,
                         JetDefinition, PseudoJet,
                         DTYPE, DTYPE_PTEPM, DTYPE_EP, USING_EXTERNAL_FASTJET)
 
+from ._version import __version__
+from ._version import FASTJET_VERSION, FJCONTRIB_VERSION
+
 __all__ = [
     'cluster',
+    DTYPE_PTEPM,
+    DTYPE_EP,
+    FASTJET_VERSION,
+    FJCONTRIB_VERSION
 ]
-
-FASTJET_VERSION = '3.3.3'
 
 
 def cluster(vectors, algo='genkt', area=None, ep=False, **kwargs):

--- a/pyjet/_version.py
+++ b/pyjet/_version.py
@@ -1,0 +1,7 @@
+__version__ = "1.6.0"
+
+version = __version__
+version_info = __version__.split(".")
+
+FASTJET_VERSION = "3.3.3"
+FJCONTRIB_VERSION = "1.042"

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ extras_require = {"dev": ["pytest"]}
 
 setup(
     name='pyjet',
-    version='1.5.0',
+    version='1.6.0',
     description='The interface between FastJet and NumPy',
     long_description=''.join(open(os.path.join(local_path, 'README.rst')).readlines()),
     author='Noel Dawe',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,12 @@ from setuptools.command.install import install as _install
 local_path = os.path.dirname(os.path.abspath(__file__))
 
 
+def get_version():
+    g = {}
+    exec(open(os.path.join("pyjet", "_version.py")).read(), g)
+    return g["__version__"]
+
+
 def fastjet_prefix(fastjet_config='fastjet-config'):
     try:
         prefix = subprocess.Popen(
@@ -96,7 +102,7 @@ extras_require = {"dev": ["pytest"]}
 
 setup(
     name='pyjet',
-    version='1.6.0',
+    version=get_version(),
     description='The interface between FastJet and NumPy',
     long_description=''.join(open(os.path.join(local_path, 'README.rst')).readlines()),
     author='Noel Dawe',


### PR DESCRIPTION
@henryiii, all your major updates - and the minor version update of FastJet - call for a new release.

I can easily prepare the release notes and tag, but am unsure of how to deploy given all your changes, which I did not fully read yet. What's the procedure to deploy? I guess it's no longer just an `sdist`?
Let me know, thanks.