### PR TITLE
Prepare release 1.7.0

### DIFF
--- a/pyjet/_version.py
+++ b/pyjet/_version.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 version = __version__
 version_info = __version__.split(".")


### PR DESCRIPTION
Release for FastJet 3.3.4 and FastJet Contrib 1.045.

Version otherwise with no extra functionality compared to version 1.6.0.