### PR TITLE
chore: bump cibuildwheel to 1.8.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Offical actions have moving tags like v1
+      # that are used, so they don't need updates here
+      - dependency-name: "actions/*"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,8 +13,6 @@ on:
       - published
 
 
-
-
 jobs:
   build_sdist:
     name: Build SDist
@@ -22,16 +20,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v2
-
-    - name: Install deps
-      run: python -m pip install build twine
-
     - name: Build SDist
-      run: python -m build -s
+      run: pipx run --spec build pyproject-build --sdist
 
     - name: Check metadata
-      run: twine check dist/*
+      run: pipx run twine check dist/*
 
     - uses: actions/upload-artifact@v2
       with:
@@ -50,17 +43,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v2
-
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.6.4
-
     - name: Install Visual C++ for Python 2.7
       if: runner.os == 'Windows'
       run:  choco install vcpython27 -f -y
 
-    - name: Build wheel
-      run: python -m cibuildwheel --output-dir wheelhouse
+    - uses: joerick/cibuildwheel@v1.8.0
       env:
         CIBW_TEST_EXTRAS: test
         CIBW_TEST_COMMAND: "pytest {project}/tests"
@@ -89,17 +76,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
 
-
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v2
-
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.6.4
-
-    - name: Build wheel
-      run: python -m cibuildwheel --output-dir wheelhouse
+    - uses: joerick/cibuildwheel@v1.8.0
       env:
         CIBW_SKIP: cp*
 


### PR DESCRIPTION
Also adds dependabot.

https://github.com/scikit-hep/scikit-hep.github.io/pull/112