### PR TITLE
Update documentation to clarify FastJet for jet areas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,8 +143,9 @@ Get example.py and run it::
 Using an External FastJet Installation
 ---------------------------------------
 
-To take advantage of the full FastJet library and optimized O(NlnN) kt and
-anti-kt algorithms you can first build and install FastJet and then install
+To take advantage of the full FastJet library, including the jet area
+calculations and the optimized O(NlnN) kt and anti-kt algorithms,
+you can first build and install FastJet and then install
 pyjet with the ``--external-fastjet`` flag. Before building FastJet you will
 need to install `CGAL <http://www.cgal.org/>`_ and `GMP
 <https://gmplib.org/>`_.


### PR DESCRIPTION
This addresses https://github.com/scikit-hep/pyjet/issues/49.

Added a line to clarify that jet areas are available only if pyjet has been configured with an external FastJet installation.