### PR TITLE
Add a deprecation warning to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,14 @@
+.. -*- mode: rst -*-
+****************************************************
+:warning:pyjet is deprecated and superseded:warning:
+****************************************************
+
+``pyjet`` has been maintained minimalistically over the past couple of years.
+In the meantime a new project started, to provide a modern Pythonic jet-finding package in the Scikit-HEP ecosystem.
+
+* **fastjet** provides official FastJet bindings to Python and Awkward Array.
+  `Refer to the GitHub repository for details. <https://github.com/scikit-hep/fastjet>`_
+
 pyjet: the interface between FastJet and NumPy
 ==============================================
 

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,10 @@
-.. -*- mode: rst -*-
-****************************************************
-:warning:pyjet is deprecated and superseded:warning:
-****************************************************
+.. warning:: **pyjet is deprecated and superseded**
 
-``pyjet`` has been maintained minimalistically over the past couple of years.
-In the meantime a new project started, to provide a modern Pythonic jet-finding package in the Scikit-HEP ecosystem.
+   * **pyjet** has been maintained minimalistically over the past couple of years.
+     In the meantime a new project started, to provide a modern Pythonic jet-finding package in the Scikit-HEP ecosystem.
 
-* **fastjet** provides official FastJet bindings to Python and Awkward Array.
-  `Refer to the GitHub repository for details. <https://github.com/scikit-hep/fastjet>`_
+   * **fastjet** provides official FastJet bindings to Python and Awkward Array.
+     `Refer to the GitHub repository for details. <https://github.com/scikit-hep/fastjet>`_
 
 pyjet: the interface between FastJet and NumPy
 ==============================================

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = pyjet
 version = file: pyjet/VERSION.txt
 description = The interface between FastJet and NumPy
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 author = Noel Dawe
 author_email = noel@dawe.me
 maintainer = The Scikit-HEP admins
@@ -46,5 +47,3 @@ install_requires =
 [options.packages.find]
 exclude =
     tests
-
-


### PR DESCRIPTION
Hi @jpivarski and @aryan26roy, I think it is time to add a deprecation warning to `pyjet` similarly to what we show for `root_numpy`, see https://github.com/scikit-hep/root_numpy/blob/master/README.rst. @henryiii and I have been maintaining this package a bit but now that your `fastjet` package seems ready enough for user consumption, better to point users to it explicitly.